### PR TITLE
Add close-trade flow + options P&L to journal

### DIFF
--- a/src/journal/models.py
+++ b/src/journal/models.py
@@ -1,20 +1,39 @@
 from __future__ import annotations
-from datetime import datetime
+from datetime import date, datetime
 from typing import List, Optional
 from sqlmodel import SQLModel, Field
 
 class JournalEntry(SQLModel, table=True):
     __tablename__ = "journal_entries"
-
-    id: Optional[int] = Field(default=None, primary_key=True)
+    
+    id: Optional[int] = Field(default=None, primary_key=True)    
+    
+    # housekeeping
     created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
     updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
 
+    # risk mgmt (optional but useful)
+    stop_price: Optional[float] = None
+    target_price: Optional[float] = None
+
+    # lifecycle
+    status: str = "open"  # "open" | "closed"
+    exit_date: Optional[date] = None
+    exit_price: Optional[float] = None
+
+    # core trade details
     symbol: str
     direction: str
     strategy: str
+    entry_date: date = Field(default_factory=date.today)
+    entry_price: float = 0.0
+    size: int = 1
     notes: str = ""
     tags_csv: str = ""  # internal storage
+
+    # options workflow: how the position was opened
+    # 'BTO' (debit) or 'STO' (credit)
+    entry_action: str = "BTO"  # allowed: "BTO" | "STO"
 
     @property
     def tags(self) -> List[str]:
@@ -24,4 +43,29 @@ class JournalEntry(SQLModel, table=True):
     def tags(self, values: List[str]) -> None:
         self.tags_csv = ",".join(v.strip() for v in values if v.strip())
 
+    def expected_exit_action(self) -> str:
+    
+    # What the close action should be, given entry_action
+        return "STC" if self.entry_action == "BTO" else "BTC"
+
+@property
+def holding_days(self) -> Optional[int]:
+    if not self.exit_date:
+        return None
+    return (self.exit_date - self.entry_date).days
+
+@property
+def realized_pl(self) -> Optional[float]:
+    """Options P&L with 100x contract multiplier.
+    BTO -> STC:   (exit - entry) * contracts * 100
+    STO -> BTC:   (entry - exit) * contracts * 100
+    """
+    if self.status != "closed" or self.exit_price is None:
+        return None
+    multiplier = 100
+    if self.entry_action == "BTO":
+        pnl = (self.exit_price - self.entry_price) * self.size * multiplier
+    else:  # STO
+        pnl = (self.entry_price - self.exit_price) * self.size * multiplier
+    return round(pnl, 2)
 

--- a/src/journal/storage.py
+++ b/src/journal/storage.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from datetime import datetime
+from datetime import date, datetime
 from sqlmodel import SQLModel, create_engine, Session, select
 
 from .models import JournalEntry
@@ -26,17 +26,43 @@ def _session() -> Session:
         init_db()
     return Session(_engine)
 
+from datetime import date  # ensure this import exists
+
 def create_entry(
-    *, symbol: str, direction: str, strategy: str, notes: str = "", tags: Optional[List[str]] = None
+    *,
+    symbol: str,
+    strategy: str,
+    entry_action: str,            # "BTO" or "STO"
+    entry_date: Optional[date] = None,
+    entry_price: float = 0.0,
+    size: int = 1,
+    direction: str = "neutral",   # metadata
+    notes: Optional[str] = None,
+    tags_csv: Optional[str] = None,
 ) -> JournalEntry:
-    entry = JournalEntry(symbol=symbol, direction=direction, strategy=strategy, notes=notes)
-    if tags:
-        entry.tags = tags
+    resolved_date = entry_date or date.today()
+    normalized_symbol = (symbol or "").strip().upper()
+    normalized_tags = (tags_csv or "").strip()
+
+    entry = JournalEntry(
+        symbol=normalized_symbol,
+        strategy=strategy,
+        entry_action=entry_action,
+        entry_date=resolved_date,
+        entry_price=float(entry_price),
+        size=int(size),
+        direction=direction,
+        notes=notes,
+        tags_csv=normalized_tags,
+        status="open",
+    )
+
     with _session() as s:
         s.add(entry)
         s.commit()
         s.refresh(entry)
-    return entry
+        return entry
+
 
 def list_entries(tag: Optional[str] = None) -> List[JournalEntry]:
     with _session() as s:
@@ -57,3 +83,35 @@ def update_entry(entry_id: int, **patch) -> JournalEntry:
         s.commit()
         s.refresh(obj)
         return obj
+
+def get_entry(entry_id: int) -> Optional[JournalEntry]:
+    with _session() as s:
+        return s.get(JournalEntry, entry_id)
+
+def close_entry(entry_id: int, exit_price: float, exit_date: Optional[date] = None) -> JournalEntry:
+    if exit_date is None:
+        exit_date = date.today()
+    with _session() as s:
+        j = s.get(JournalEntry, entry_id)
+        if not j:
+            raise ValueError(f"Entry {entry_id} not found")
+        j.exit_price = float(exit_price)
+        j.exit_date = exit_date
+        j.status = "closed"
+        s.add(j)
+        s.commit()
+        s.refresh(j)
+        return j
+
+def delete_entry(entry_id: int) -> None:
+    # hard delete for now (simple dev DB). If you prefer soft delete, add a boolean column.
+    with _session() as s:
+        j = s.get(JournalEntry, entry_id)
+        if j:
+            s.delete(j)
+            s.commit()
+
+def list_entries_by_status(status: str) -> List[JournalEntry]:
+    with _session() as s:
+        q = select(JournalEntry).where(JournalEntry.status == status)
+        return list(s.exec(q).all())

--- a/tests/test_close_entry.py
+++ b/tests/test_close_entry.py
@@ -1,0 +1,19 @@
+from datetime import date
+from src.journal.models import JournalEntry
+from src.journal.storage import init_db, create_entry, close_entry, list_entries_by_status
+from src.settings import Settings
+
+def test_close_entry(tmp_path):
+    db_path = tmp_path / "test.db"
+    init_db(Settings(database_url=f"sqlite:///{db_path}"))
+
+    j = create_entry(symbol="AAPL", side="long", entry_date=date(2025,1,1), entry_price=100.0, size=10)
+    assert j.status == "open"
+
+    closed = close_entry(j.id, exit_price=110.0, exit_date=date(2025,1,2))
+    assert closed.status == "closed"
+    assert closed.exit_price == 110.0
+
+    closed_list = list_entries_by_status("closed")
+    assert any(x.id == j.id for x in closed_list)
+    assert closed.realized_pl == 100.0  # (110-100)*10


### PR DESCRIPTION
New inputs: entry date (defaults to today), entry price, contracts.

Options flow: BTO/STO captured as entry_action.

Close flow: mark trade closed, capture exit price/date.

P&L logic: BTO→STC (exit-entry) * contracts * 100; STO→BTC (entry-exit) * contracts * 100.

UI: moved “direction” to metadata row; tags normalized to tags_csv.

